### PR TITLE
Fix readme, index, crowsetta name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <div align="center"><img src="./doc/_static/crowsetta-primary-logo.png" width="400"></div>
 <hr>
 
-## a tool to work with any format for annotating vocalizations
+## A Python tool to work with any format for annotating animal vocalizations and bioacoustics data
 
 [![Build Status](https://github.com/NickleDave/crowsetta/actions/workflows/ci.yml/badge.svg)](https://github.com/NickleDave/crowsetta/actions)
 [![Documentation Status](https://readthedocs.org/projects/crowsetta/badge/?version=latest)](https://crowsetta.readthedocs.io/en/latest/?badge=latest)
@@ -10,79 +10,92 @@
 [![PyPI version](https://badge.fury.io/py/crowsetta.svg)](https://badge.fury.io/py/crowsetta)
 [![codecov](https://codecov.io/gh/NickleDave/crowsetta/branch/main/graph/badge.svg?token=TXtNTxXKmb)](https://codecov.io/gh/NickleDave/crowsetta)
 
-`crowsetta` is a tool to work with any format for annotating vocalizations: speech, birdsong,
-mouse ultrasonic calls (insert your favorite animal vocalization here).
-**The goal of** `crowsetta` **is to make sure that your ability to work with a dataset
-of vocalizations does not depend on your ability to work with any given format for
-annotating that dataset.** What `crowsetta` gives you is **not** yet another format for
-annotation (I promise!); instead you get some nice data types that make it easy to
-work with any format: namely, `Sequence`s made up of `Segment`s.
+crowsetta provides a Pythonic way to work with annotation formats 
+for animal vocalizations and bioacoustics data. 
+These formats are used, for example, by 
+applications that enable users to annotate audio and/or spectrograms. 
+Such annotations typically include the times when sound events start and stop, 
+and labels that assign each sound to some set of classes 
+chosen by the annotator.
+crowsetta has built-in support for many widely used 
+[formats](https://crowsetta.readthedocs.io/en/latest/formats/index.html),
+such as 
+[Audacity label tracks](https://crowsetta.readthedocs.io/en/latest/formats/seq/aud-txt.html#aud-txt), 
+[Praat .TextGrid files](https://crowsetta.readthedocs.io/en/latest/formats/seq/textgrid.html#textgrid), 
+and [Raven .txt files](https://crowsetta.readthedocs.io/en/latest/formats/bbox/raven.html#raven).
 
-```Python
-    >>> from crowsetta import Segment, Sequence
-    >>> a_segment = Segment.from_keyword(
-    ...     label='a',
-    ...     onset_ind=16000,
-    ...     offset_ind=32000,
-    ...     file='bird21.wav'
-    ...     )
-    >>> list_of_segments = [a_segment] * 3
-    >>> seq = Sequence(segments=list_of_segments)
-    >>> print(seq)
-    Sequence(segments=[Segment(label='a', onset_s=None, offset_s=None, onset_ind=16000,
-    offset_ind=32000, file='bird21.wav'), Segment(label='a', onset_s=None, offset_s=None,
-    onset_ind=16000, offset_ind=32000, file='bird21.wav'), Segment(label='a', onset_s=None,
-    offset_s=None, onset_ind=16000, offset_ind=32000, file='bird21.wav')])
-```
+---
 
-You can load annotation from your format of choice into `Sequence`s of `Segment`s
-(most conveniently with the `Transcriber`, as explained below) and then use the
-`Sequence`s however you need to in your program.
+<img align="left"
+width="600"
+alt="example spectrogram showing Bengalese finch song with Praat TextGrid annotations indicated as segments underneath"
+src="./doc/_static/example-textgrid-for-index.png">
 
-For example, if you want to loop through the `Segment`s of each `Sequence`s to
-pull syllables out of a spectrogram, you can do something like this, very Pythonically:
+Spectrogram of the song of a Bengalese finch 
+with syllables annotated as segments underneath. 
+Annotations parsed by crowsetta 
+from a file in the Praat .TextGrid  format.
+Example song from 
+[Bengalese finch song dataset](https://osf.io/r6paq/), 
+Tachibana and Morita 2021, adapted under 
+CC-By-4.0 License.
 
-```Python
-   >>> syllables_from_sequences = []
-   >>> for a_seq in seq:
-   ...     seq_dict = seq.to_dict()  # convert to dict with
-   ...     spect = some_spectrogram_making_function(seq['file'])
-   ...     syllables = []
-   ...     for seg in seq.segments:
-   ...         syllable = spect[:, seg.onset:seg.offset]  ## spectrogram is a 2d numpy array
-   ...         syllables.append(syllable)
-   ...     syllables_from_sequences.append(syllables)
-```
+<br>
 
-As mentioned above, `crowsetta` provides you with a `Transcriber` that comes equipped
-with convenience functions to do the work of converting for you.
+<br>
 
-```Python
-    from crowsetta import Transcriber
-    scribe = Transcriber()
-    seq = scribe.to_seq(file=notmat_files, format='notmat')
-```
+---
 
-You can even easily adapt the `Transcriber` to use your own in-house format, like so:
+<img align="left"
+width="600"
+alt="example spectrogram from field recording with Raven annotations of birdsong indicated as rectangular bounding boxes"
+src="./doc/_static/example-raven-for-index.png">
 
-```Python
-    from crowsetta import Transcriber
-    scribe = Transciber(user_config=your_config)
-    scribe.to_csv(file_'your_annotation_file.mat',
-                  csv_filename='your_annotation.csv')
-```
+Spectrogram of a field recording 
+with annotations of songs of different bird species
+indicated as bounding boxes.
+Annotations parsed by crowsetta 
+from a file in the 
+[Raven Selection Table](https://crowsetta.readthedocs.io/en/latest/formats/bbox/raven.html#raven) 
+format.
+Example song from 
+["An annotated set of audio recordings of Eastern North American birds containing frequency, time, and species information"](https://esajournals.onlinelibrary.wiley.com/doi/full/10.1002/ecy.3329), 
+Chronister et al., 2021, adapted under 
+CC0 1.0 License.
+
+---
+
+Who would want to use crowsetta?
+Anyone that works with animal vocalizations 
+or other bioacoustics data that is annotated in some way.
+Maybe you are a neuroscientist trying to figure out how songbirds learn their song,
+or why mice emit ultrasonic calls. Or maybe you're an ecologist studying dialects of finches
+distributed across Asia, or maybe you are a linguist studying accents in the
+Caribbean, or a speech pathologist looking for phonetic changes that indicate early onset
+Alzheimer's disease. crowsetta makes it easier for you to work with 
+your annotations in Python, regardless of the format.
 
 ## Features
 
-- convert annotation formats to `Sequence` objects that can be easily used in a Python program
-- convert `Sequence` objects to comma-separated value text files that can be read on any system
-- load comma-separated values files back into Python and convert to other formats
-- easily use with your own annotation format
+* take advantage of built-in support 
+  for many widely used
+  [formats](https://crowsetta.readthedocs.io/en/latest/formats/index.html),
+  such as 
+  [Audacity label tracks](https://crowsetta.readthedocs.io/en/latest/formats/seq/aud-txt.html#aud-txt), 
+  [Praat .TextGrid files](https://crowsetta.readthedocs.io/en/latest/formats/seq/textgrid.html#textgrid), 
+  and [Raven .txt files](https://crowsetta.readthedocs.io/en/latest/formats/bbox/raven.html#raven).
+* work with any format by remembering just one class:  
+  `annot = crowsetta.Transcriber(format='format').from_file('annotations.ext')`
+  - no need to remember different functions for different formats 
+* when needed, use classes that represent the formats 
+  to write readable scripts and libraries 
+* convert annotations to common file formats like `.csv`
+  that anyone can work with
+* work with custom formats that are not built in to `crowsetta` 
+  by writing simple classes, leveraging abstractions 
+  that can represent a wide array of annotation formats
 
-You might find it useful in any situation where you want
-to share audio files of song and some associated annotations,
-but you don't want to require the user to install a large
-application in order to work with the annotation files.
+For examples of these features, please see: https://crowsetta.readthedocs.io/en/latest/index.html#features
 
 ## Getting Started
 ### Installation
@@ -99,47 +112,39 @@ $ conda install crowsetta -c conda-forge
 ```
 
 ### Usage
-To learn how to use `crowsetta`, please see the documentation at:  
-<https://crowsetta.readthedocs.io/en/latest/index.html>
 
-### Development Installation
+If you are new to crowsetta, start with 
+[tutorial](https://crowsetta.readthedocs.io/en/latest/tutorial.html).
 
-Currently `crowsetta` is developed with `conda`.
-To set up a development environment:
-```
-$ conda create crowsetta-dev
-$ conda create -n crowsetta-dev python=3.6 numpy scipy attrs
-$ conda activate crowsetta-dev
-$ $ pip install evfuncs koumura
-$ git clone https://github.com/NickleDave/crowsetta.git
-$ cd crowsetta
-$ pip install -e .
-```
-
+For vignettes showing how to use crowsetta for various tasks, 
+such as working with your own annotation format, 
+please see the [how-to](https://crowsetta.readthedocs.io/en/latest/howto.html)
+section.
 
 ## Project Information
 
 ### Background
 
-`crowsetta` was developed for two libraries:
-- `hybrid-vocal-classifier` <https://github.com/NickleDave/hybrid-vocal-classifier>
-- `vak` <https://github.com/NickleDave/vak>
-
-Testing relies on the `Vocalization Annotation Formats Dataset` which you may find useful if you need
-small samples of different audio files and associated annotation formats
-- on Figshare: <https://figshare.com/articles/Vocalization_Annotation_Formats_Dataset/8046920>
-- built from this GitHub repository: <https://github.com/NickleDave/vocal-annotation-formats>
+crowsetta was developed for two libraries:
+- `hybrid-vocal-classifier` <https://github.com/vocalpy/hybrid-vocal-classifier>
+- `vak` <https://github.com/vocalpy/vak>
 
 ### Support
 
-If you are having issues, please let us know.
+To report a bug or request a feature (such as a new annotation format), 
+please use the issue tracker on GitHub:  
+<https://github.com/vocalpy/crowsetta/issues>
 
-- Issue Tracker: <https://github.com/NickleDave/crowsetta/issues>
+To ask a question about crowsetta, discuss its development, 
+or share how you are using it, 
+please start a new topic on the VocalPy forum 
+with the crowsetta tag:  
+<https://forum.vocalpy.org/>
 
 ### Contribute
 
-- Issue Tracker: <https://github.com/NickleDave/crowsetta/issues>
-- Source Code: <https://github.com/NickleDave/crowsetta>
+- Issue Tracker: <https://github.com/vocalpy/crowsetta/issues>
+- Source Code: <https://github.com/vocalpy/crowsetta>
 
 ### CHANGELOG
 You can see project history and work in progress in the [CHANGELOG](./doc/CHANGELOG.md)
@@ -149,5 +154,5 @@ You can see project history and work in progress in the [CHANGELOG](./doc/CHANGE
 The project is licensed under the [BSD license](./LICENSE).
 
 ### Citation
-If you use `crowsetta`, please cite the DOI:
+If you use crowsetta, please cite the DOI:
 [![DOI](https://zenodo.org/badge/159904494.svg)](https://zenodo.org/badge/latestdoi/159904494)

--- a/doc/api/core.md
+++ b/doc/api/core.md
@@ -2,7 +2,7 @@
 
 # Core
 
-This page documents the core API of `crowsetta`, 
+This page documents the core API of crowsetta, 
 including data types, other classes, and modules.
 
 ## Data types

--- a/doc/api/formats.md
+++ b/doc/api/formats.md
@@ -4,7 +4,7 @@
 
 This page documents the API of the `crowsetta.formats` module.
 It is generated automatically. 
-If you are a `crowsetta` user looking for 
+If you are a crowsetta user looking for 
 more detail about the built-in formats,
 please see: {ref}`formats-index`.
 

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -6,13 +6,13 @@
 
 This section documents the 
 [API](https://en.wikipedia.org/wiki/API)
-of `crowsetta`.
+of crowsetta.
 
 ```{list-table}
 :widths: 30 70
 
 * - {ref}`Core <api-core>`
-  - The core data types, classes and modules of `crowsetta`
+  - The core data types, classes and modules of crowsetta
 * - {ref}`Interface <api-interface>`
   - Defines an interface for classes that represent annotation formats
 * - {ref}`Formats <api-formats>`

--- a/doc/formats/index.md
+++ b/doc/formats/index.md
@@ -2,7 +2,7 @@
 
 # Formats
 
-This page documents the annotation formats built in to `crowsetta`. 
+This page documents the annotation formats built in to crowsetta. 
 The purpose of this section is to provide more information about 
 the formats themselves, including links, citations, 
 and schema where possible.

--- a/doc/formats/seq/notmat.md
+++ b/doc/formats/seq/notmat.md
@@ -13,7 +13,7 @@ Nature 450.7173 (2007): 1240.
 This format is used for the dataset in this repository:
 <https://figshare.com/articles/dataset/Bengalese_Finch_song_repository/4805749>
 
-Internally, `crowsetta` loads this format using the 
+Internally, crowsetta loads this format using the 
 Python tool [evfuncs](https://github.com/NickleDave/evfuncs).
 
 The annotations can be loaded with the following class: 

--- a/doc/formats/seq/textgrid.md
+++ b/doc/formats/seq/textgrid.md
@@ -8,9 +8,9 @@ More details about annotating with Praat can be found here:
 The specification for TextGrid objects is here: 
 <https://www.fon.hum.uva.nl/praat/manual/TextGrid.html>
 
-Internally, `crowsetta` uses the Python tool `textgrid`
+Internally, crowsetta uses the Python tool `textgrid`
 (<https://github.com/kylebgorman/textgrid>) to load .TextGrid files. 
-A version is distributed with `crowsetta` 
+A version is distributed with crowsetta 
 under [MIT license](https://github.com/kylebgorman/textgrid/blob/master/LICENSE).
 
 The annotations can be loaded with the following class: 

--- a/doc/formats/seq/timit.md
+++ b/doc/formats/seq/timit.md
@@ -7,7 +7,7 @@ DARPA TIMIT Acoustic-Phonetic Continuous Speech Corpus (TIMIT).
 See the README for the dataset here in the U. Penn Catalog:  
 <https://catalog.ldc.upenn.edu/docs/LDC93S1/timit.readme.html>
 
-The formats that can be loaded with `crowsetta` are those used 
+The formats that can be loaded with crowsetta are those used 
 by the .wrd and .phn transcription files, 
 where each segment is specified in terms of 
 the sample number in the audio files where it begins, 

--- a/doc/howto.md
+++ b/doc/howto.md
@@ -2,7 +2,7 @@
 
 # **How-To**
 
-This section shows you how to use `crowsetta` for specific tasks.
+This section shows you how to use crowsetta for specific tasks.
 
 ```{toctree}
 :maxdepth: 1

--- a/doc/howto/howto-user-format.md
+++ b/doc/howto/howto-user-format.md
@@ -13,15 +13,15 @@ kernelspec:
 
 (howto-user-format)=
 
-# How to use `crowsetta` with your own annotation format
+# How to use crowsetta with your own annotation format
 
-This section shows you how to use `crowsetta` for working with your
+This section shows you how to use crowsetta for working with your
 own annotation format for vocalizations (or some other format not
 currently built into the library).
 
-## Steps to using `crowsetta` with your own annotation format
+## Steps to using crowsetta with your own annotation format
 
-Below we’ll walk through a case study for using `crowsetta` with your
+Below we’ll walk through a case study for using crowsetta with your
 annotation format. Here’s an outline of the steps we’ll go through:
 
 1. get your annotations into some variables in Python (maybe you already
@@ -31,7 +31,7 @@ annotation format. Here’s an outline of the steps we’ll go through:
 4. use your format with the `crowsetta.Transcriber` class to work with your annotations
 
 If writing a class to represent your format sounds difficult, 
-don't worry. We show you how and `crowsetta` gives you tools that 
+don't worry. We show you how and crowsetta gives you tools that 
 make it easy. If you've written some Python code 
 to work with your annotations before 
 then you're probably already halfway done.
@@ -43,7 +43,7 @@ stop time, and label. Many common annotation formats for animal vocalizations
 are sequence-like.
 
 ```{note}
-Sequence-like formats are one of the two types in `crowsetta`. 
+Sequence-like formats are one of the two types in crowsetta. 
 The other is {ref}`bounding-box <formats-bbox-like>` formats, 
 which annotate sound events with boxes, as the name implies. 
 The steps for working with your own bounding box-like format 
@@ -116,7 +116,7 @@ can run your analysis scripts and reproduce your figures for himself.
 What you really want is to share your data and write your code in a way
 that doesn’t depend on anyone knowing anything about `BatLAB`
 or`SoNAR` and how those programs save data and annotations. This is
-where `crowsetta` comes to your rescue.
+where crowsetta comes to your rescue.
 
 Okay, now that we’ve set up some background for our case study, let’s go
 through the steps we outlined above.
@@ -296,7 +296,7 @@ the [`attrs` library](https://www.attrs.org/en/stable/).
 Then we later add a couple methods to this class that do things 
 like turn the annotations into `crowsetta.Sequence`s and `crowsetta.Annotation`s.
 
-To start writing the class, copy one of the existing classes in `crowsetta`, by looking at its code.  
+To start writing the class, copy one of the existing classes in crowsetta, by looking at its code.  
 Here's a stub of a `Batlab` class that we wrote by 
 copying the [`'yarden'` format](https://github.com/vocalpy/crowsetta/blob/main/src/crowsetta/formats/seq/yarden.py) and changing a couple things -- we'll explain what we changed below.
 
@@ -355,7 +355,7 @@ class Batlab:
 
 This might seem overwhelming at first, but we only changed a few things.
 
-To tell `crowsetta` how to handle our format,
+To tell crowsetta how to handle our format,
 we need to change exactly two of the class attributes: 
 (1) the `name` and (2) the `ext`.
 
@@ -363,7 +363,7 @@ The `name` attribute is the shorthand string name that we use to refer to our fo
 for example when we call `crowsetta.format.by_name` or we make a new `Transcriber`, 
 passing in this `name` as the `format` argument (like so: `scribe = crowsetta.Transcriber(format='name')`).
 
-The `ext` attribute tells `crowsetta` what a valid file extension is for this annotation format: 
+The `ext` attribute tells crowsetta what a valid file extension is for this annotation format: 
 is it a `.mat` file or a `.csv` file? Can it be both `('txt', 'csv')`? 
 We then use this attribute in other places in the class, 
 like when we write a `from_file` method, to validate the file name that gets passed into that method.
@@ -503,7 +503,7 @@ To see the entire example, check out the [batlab.py](./batlab.py) file
 
 ### 3. Register your new format by calling `crowsetta.register_format`
 
-To make it so that `crowsetta` knows about your format, 
+To make it so that crowsetta knows about your format, 
 you call the `crowsetta.register_format` function 
 and pass in the class you have written.
 
@@ -546,7 +546,7 @@ class Batlab:
 check out this primer: https://realpython.com/primer-on-python-decorators/)
 
 This works because decorators are executed at import time. 
-Notice we also used other decorators, another from `crowsetta` 
+Notice we also used other decorators, another from crowsetta 
 that registers our class as sequence-like, 
 and one from `attrs` that helps us easily define a class.
 You need to make sure that `reigster_format` the outermost decorator, 

--- a/doc/index.md
+++ b/doc/index.md
@@ -93,7 +93,7 @@ Caribbean, or a speech pathologist looking for phonetic changes that indicate ea
 Alzheimer's disease. crowsetta makes it easier for you to work with 
 your annotations in Python, regardless of the format.
 
-`crowsetta` was developed for use with the libraries 
+crowsetta was developed for use with the libraries 
 [vak](https://vak.readthedocs.io/en/latest/)
 and
 [hybrid-vocal-classifier](https://hybrid-vocal-classifier.readthedocs.io/en/latest/).
@@ -132,7 +132,7 @@ and
   to write readable scripts and libraries 
 * convert annotations to common file formats like `.csv`
   that anyone can work with
-* work with custom formats that are not built in to `crowsetta` 
+* work with custom formats that are not built in to crowsetta 
   by writing simple classes, leveraging abstractions 
   that can represent a wide array of annotation formats
 
@@ -321,7 +321,7 @@ For more about how that works, please see {ref}`howto-user-format`.
 
 If you are new to the library, start with {ref}`tutorial`.
 
-To see an example of using `crowsetta` to work with your own annotation format,
+To see an example of using crowsetta to work with your own annotation format,
 see {ref}`howto-user-format`.
 
 ```{toctree}
@@ -363,7 +363,7 @@ You can see project history and work in progress in the
 
 ## Citation
 
-If you use `crowsetta`, please cite the DOI:
+If you use crowsetta, please cite the DOI:
 
 ```{image} https://zenodo.org/badge/159904494.svg
 :target: https://zenodo.org/badge/latestdoi/159904494

--- a/doc/index.md
+++ b/doc/index.md
@@ -58,10 +58,10 @@ name: example-textgrid-for-index
 **Spectrogram of the song of a Bengalese finch 
 with syllables annotated as segments underneath. 
 Annotations parsed by crowsetta 
-from a file in the {ref}`Praat TextGrid <textgrid>`.
+from a file in the {ref}`Praat TextGrid <textgrid>` format.
 Example song from 
 [Bengalese finch song dataset](https://osf.io/r6paq/), 
-Tachibana and Morita 2021, adapated under 
+Tachibana and Morita 2021, adapted under 
 CC-By-4.0 License.**
 :::
 
@@ -79,7 +79,7 @@ Annotations parsed by crowsetta
 from a file in the {ref}`Raven Selection Table <raven>` format.
 Example song from 
 ["An annotated set of audio recordings of Eastern North American birds containing frequency, time, and species information"](https://esajournals.onlinelibrary.wiley.com/doi/full/10.1002/ecy.3329), 
-Chronister et al., 2021, adapated under 
+Chronister et al., 2021, adapted under 
 CC0 1.0 License.**
 :::
 

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -15,9 +15,9 @@ kernelspec:
 
 # Tutorial
 
-This tutorial introduces users to `crowsetta`.
+This tutorial introduces users to crowsetta.
 
-## Finding out what annotation formats are built in to `crowsetta`
+## Finding out what annotation formats are built in to crowsetta
 
 The first thing we need to do to work with any Python library is import
 it.
@@ -35,7 +35,7 @@ crowsetta.formats.as_list()
 
 ## Getting some example data to work with
 
-Since `crowsetta` is a tool to working with annotations of
+Since crowsetta is a tool to working with annotations of
 vocalizations, we need some audio files containing vocalizations that
 are annotated.
 
@@ -68,7 +68,7 @@ print(f'The first five are:\n{first_five}')
 
 ## Using the `Transcriber` to load annotation files
 
-Now we want to use `crowsetta` to load the annotations from files.
+Now we want to use crowsetta to load the annotations from files.
 
 First we get all the annotation files in some variable.
 (We have already done this using `pathlib.Path.glob` above.)
@@ -106,10 +106,10 @@ Now that we have loaded the annotations, we want to get them into some
 *data type* that makes it easier to get what we want out of the annotated files 
 (in this case, audio files).
 Just like Python has data types like a `list` or `dict` that make it
-easy to work with data, `crowsetta` provides data types meant to 
+easy to work with data, crowsetta provides data types meant to 
 work with many different formats.
 
-For any format built into `crowsetta`, we can convert the annotations 
+For any format built into crowsetta, we can convert the annotations 
 that we load into a generic `crowsetta.Annotation` (or a `list` of 
 `Annotation`s, if a single annotation file contains annotations 
 for multiple annotated audio files or spectrograms).
@@ -231,7 +231,7 @@ print("\nFirst two Segments of first Sequence:")
 for seg in seqs[0].segments[0:2]: print(seg)
 ```
 
-## **Using** `crowsetta` **data types to write clean code**
+## **Using** crowsetta **data types to write clean code**
 
 Now that we have a `list` of `Sequence`s, we can `iterate`
 (loop) through it to get at our  data in a clean, Pythonic way.
@@ -310,7 +310,7 @@ We can see that each phrase has a roughly similar distribution of durations. We 
 
 +++
 
-Okay, now you’ve seen the basics of working with `crowsetta`. Get out
+Okay, now you’ve seen the basics of working with crowsetta. Get out
 there and analyze some vocalizations!
 
 ```{code-cell} ipython3


### PR DESCRIPTION
- clean up README, including fixing description -- fixes #199 
- fix typos in index
- throughout docs, write crowsetta in default font instead of as monospace