### PR TITLE
Fix codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
           pip install '.[test]'
           nox --session coverage
       - name: upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ## A Python tool to work with any format for annotating animal vocalizations and bioacoustics data
 
-[![Build Status](https://github.com/NickleDave/crowsetta/actions/workflows/ci.yml/badge.svg)](https://github.com/NickleDave/crowsetta/actions)
+[![Build Status](https://github.com/vocalpy/crowsetta/actions/workflows/ci.yml/badge.svg)](https://github.com/vocalpy/crowsetta/actions)
 [![Documentation Status](https://readthedocs.org/projects/crowsetta/badge/?version=latest)](https://crowsetta.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/159904494.svg)](https://zenodo.org/badge/latestdoi/159904494)
 [![PyPI version](https://badge.fury.io/py/crowsetta.svg)](https://badge.fury.io/py/crowsetta)
-[![codecov](https://codecov.io/gh/NickleDave/crowsetta/branch/main/graph/badge.svg?token=TXtNTxXKmb)](https://codecov.io/gh/NickleDave/crowsetta)
+[![codecov](https://codecov.io/gh/vocalpy/crowsetta/branch/main/graph/badge.svg?token=TXtNTxXKmb)](https://codecov.io/gh/vocalpy/crowsetta)
 
 crowsetta provides a Pythonic way to work with annotation formats 
 for animal vocalizations and bioacoustics data. 


### PR DESCRIPTION
Changes version of codecov action used on CI, and changes badges to point at vocalpy not NickleDave, which should trigger creation of a vocalpy/crowsetta project on codecov (I think)