### PR TITLE
BUG: Coerce GenericSeq path attributes to str

### DIFF
--- a/src/crowsetta/formats/seq/generic.py
+++ b/src/crowsetta/formats/seq/generic.py
@@ -46,8 +46,8 @@ class GenericSeqSchema(pandera.SchemaModel):
     onset_sample: Optional[Series[int]] = pandera.Field()
     offset_sample: Optional[Series[int]] = pandera.Field()
 
-    notated_path: Series[str] = pandera.Field()
-    annot_path: Series[str] = pandera.Field()
+    notated_path: Series[str] = pandera.Field(coerce=True)
+    annot_path: Series[str] = pandera.Field(coerce=True)
     sequence: Series[int] = pandera.Field()
     annotation: Series[int] = pandera.Field()
 


### PR DESCRIPTION
Hoping this will fix CI failures.

We coerce the `annot_path` and `notated_path` attributes of the pandera GenericSeq schema to be strings -- apparently they get passed in as pathlib.Path on CI somehow? I can't reproduce the error locally. But coercing them to string seems to fix it. And it makes sense in general to force these attributes to be strings since there's no `pathlib` dtype for pandas DataFrames (without using a library like pandas-pathlib)