### PR TITLE
Make fixes for Windows / CI

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import shutil
+import sys
 
 import nox
 
@@ -43,7 +44,10 @@ def dev(session: nox.Session) -> None:
     # e.g. .venv
     session.run("virtualenv", os.fsdecode(VENV_DIR), silent=True)
 
-    python = os.fsdecode(VENV_DIR.joinpath("bin/python"))
+    if sys.platform.startswith("linux") or sys.platform == "darwin":
+        python = os.fsdecode(VENV_DIR.joinpath("bin/python"))
+    elif sys.platform.startswith("win"):
+        python = os.fsdecode(VENV_DIR.joinpath("Scripts/python.exe"))
 
     # Use the venv's interpreter to install the project along with
     # all it's dev dependencies, this ensures it's installed in the right way

--- a/src/crowsetta/segment.py
+++ b/src/crowsetta/segment.py
@@ -5,13 +5,13 @@ import numpy as np
 from attr.validators import instance_of
 
 
-def int64_to_int(val):
-    """Converter that converts ``numpy.int64`` to ``int``,
-    returns ``int`` as is, and errors for other values.
+def convert_int(val):
+    """Converter that converts ``numpy.integer`` to ``int``,
+    returns native Python ``int`` as is, and
+    raises an error for any other type.
     """
-    if hasattr(val, "dtype"):
-        if val.dtype == np.int64:
-            return int(val)
+    if hasattr(val, "dtype") and isinstance(val, np.integer):
+        return int(val)
     elif isinstance(val, int):
         return val
     else:
@@ -81,12 +81,12 @@ class Segment(object):
     offset_s = attr.ib(validator=attr.validators.optional(instance_of(float)), default=None)
     onset_sample = attr.ib(
         validator=attr.validators.optional(instance_of(int)),
-        converter=attr.converters.optional(int64_to_int),
+        converter=attr.converters.optional(convert_int),
         default=None,
     )
     offset_sample = attr.ib(
         validator=attr.validators.optional(instance_of(int)),
-        converter=attr.converters.optional(int64_to_int),
+        converter=attr.converters.optional(convert_int),
         default=None,
     )
     asdict = attr.asdict

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -53,7 +53,7 @@ def test_from_keyword_bad_labels_type_raises():
         Sequence.from_keyword(labels=labels, onset_samples=onset_samples, offset_samples=offset_samples)
 
 
-def test_from_keyword__onset_offset_in_seconds():
+def test_from_keyword_onset_offset_in_seconds():
     labels = "abcde"
     onsets_s = np.asarray([0.0, 0.2, 0.4, 0.6, 0.8])
     offsets_s = np.asarray([0.1, 0.3, 0.5, 0.7, 0.9])
@@ -62,7 +62,7 @@ def test_from_keyword__onset_offset_in_seconds():
     assert type(seq.segments) == tuple
 
 
-def test_from_keyword_onset_offset_in_Hertz():
+def test_from_keyword_onset_offset_in_samples():
     labels = "abcde"
     onset_samples = np.asarray([0, 2, 4, 6, 8])
     offset_samples = np.asarray([1, 3, 5, 7, 9])
@@ -82,7 +82,7 @@ def test_from_dict_onset_offset_in_seconds():
     assert type(seq.segments) == tuple
 
 
-def test_from_dict_onset_offset_in_Hertz():
+def test_from_dict_onset_offset_in_samples():
     seq_dict = {
         "labels": "abcde",
         "onset_samples": np.asarray([0, 2, 4, 6, 8]),
@@ -108,17 +108,17 @@ def test_missing_onset_seconds_raises():
         Sequence.from_keyword(labels="abcde", offsets_s=np.asarray([0.0, 0.2, 0.4, 0.6, 0.8]))
 
 
-def test_missing_offset_Hertz_raises():
+def test_missing_offset_samples_raises():
     with pytest.raises(ValueError):
         Sequence.from_keyword(labels="abcde", onset_samples=np.asarray([0, 2, 4, 6, 8]))
 
 
-def test_missing_onset_Hertz_raises():
+def test_missing_onset_samples_raises():
     with pytest.raises(ValueError):
         Sequence.from_keyword(labels="abcde", offset_samples=np.asarray([0, 2, 4, 6, 8]))
 
 
-def test_as_dict_onset_offset_in_Hertz():
+def test_as_dict_onset_offset_in_samples():
     labels = "abcde"
     onset_samples = np.asarray([0, 2, 4, 6, 8])
     offset_samples = np.asarray([1, 3, 5, 7, 9])


### PR DESCRIPTION
- Fixes the Nox session 'dev' so it works on Windows
- Fix how we convert numpy integers to Python native integers for Segment instances, so that it doesn't fail on Windows, where the default numpy integer dtype is int32 not int64