### PR TITLE
Dev cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.10"]
+        python-version: [3.9, "3.10", 3.11]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
           src: "./src"
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: "3.10"
       - name: install libsndfile1 on ubuntu
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt install libsndfile1

--- a/noxfile.py
+++ b/noxfile.py
@@ -66,7 +66,14 @@ def lint(session):
     session.run("flake8", "./src", "--max-line-length", "120", "--exclude", "./src/crowsetta/_vendor")
 
 
-@nox.session
+TEST_PYTHONS = [
+    "3.9",
+    "3.10",
+    "3.11"
+]
+
+
+@nox.session(python=TEST_PYTHONS)
 def test(session) -> None:
     """
     Run the unit and regular tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "attrs >=19.3.0",
     "evfuncs >=0.3.5",
     "birdsong-recognition-dataset >=0.3.2",
-    "importlib-resources >=5.7.1",
     "numpy >=1.21.0",
     "pandas >= 1.3.5",
     "pandera >= 0.9.0",


### PR DESCRIPTION
- [x] Drop importlib-resources as dependency, not needed now that we require Python >=3.9
- [x]  Have nox session 'tests' run on Python 3.9-3.11
- [x]  Also have CI run tests on Python 3.9-3.11
- [x] Use Python 3.10 for lint session, hopefully fixes weird pip resolver bug along with removing the importlib-resources dependency 