### PR TITLE
DOC: Finish munging howto fixup, other clean-ups

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ build:
   apt_packages:
     - libsndfile1
   tools:
-    python: "3.8"
+    python: "3.10"
 
 sphinx:
    configuration: doc/conf.py

--- a/doc/howto.md
+++ b/doc/howto.md
@@ -10,5 +10,5 @@ This section shows you how to use crowsetta for specific tasks.
 howto/howto-user-format
 howto/convert-generic-seq
 howto/convert-simple-seq
-howto/remove-silent-labels-textgrid
+howto/munging-annotations-textgrid
 ```

--- a/doc/howto/convert-simple-seq.md
+++ b/doc/howto/convert-simple-seq.md
@@ -36,7 +36,7 @@ of annotation formats that map directly to machine learning tasks,
 and makes it easy to convert your annotations 
 in widely used formats to these simplified representations.
 
-This vignette shows how to convert {ref}`sequence-like <sequence-like-formats>` annotations 
+This vignette shows how to convert {ref}`sequence-like <formats-seq-like>` annotations 
 to a simplified format that is useful for tasks 
 such as building data sets for machine learning.
 In this vignette, we write an example small Python script
@@ -80,7 +80,7 @@ and the vak library similarly allows for
 ### What types of annotation formats will this work with
 
 The approach shown here will work for a wide array of annotation formats 
-that crowsetta calls {ref}`sequence-like <sequence-like-formats>`,
+that crowsetta calls {ref}`sequence-like <formats-seq-like>`,
 because they can all be represented as a sequence of segments, 
 with each segment having an onset time, offset time, and label.
 
@@ -97,7 +97,7 @@ We use the Audacity format in this vignette.
 ### Downloading the example dataset
 
 We download some examples of annotation files in the 
-{ref}`Audacity LabelTrack format <aud-txt>`, 
+{ref}`Audacity LabelTrack format <aud-seq>`, 
 from the dataset 
 ["Labeled songs of domestic canary M1-2016-spring (Serinus canaria)"](https://zenodo.org/record/6521932)
 by Giraudon et al., 2021.

--- a/doc/howto/munging-annotations-textgrid.md
+++ b/doc/howto/munging-annotations-textgrid.md
@@ -296,10 +296,9 @@ Our TextGrid files are in a sub-directory, `./data/r6pqa` (the unique ID associa
 We get a list of the TextGrid files from that subdirectory using `pathlib`.
 
 To download these files and work with them locally, click the following links:
-{download}`b06_concat_dtw.TextGrid <data/r6paq/b06_concat_dtw.TextGrid>`  
-{download}`b11_concat_dtw.TextGrid<data/r6paq/b11_concat_dtw.TextGrid>`  
-{download}`b17_concat_dtw.TextGrid <data/r6paq/b17_concat_dtw.TextGrid>`  
-{download}`b35_concat_dtw.TextGrid <data/r6paq/b35_concat_dtw.TextGrid>`  
+{download}`b06_concat_dtw.TextGrid<../data/r6paq/b06_concat_dtw.TextGrid>`  
+{download}`b11_concat_dtw.TextGrid<../data/r6paq/b11_concat_dtw.TextGrid>`
+{download}`b35_concat_dtw.TextGrid<../data/r6paq/b35_concat_dtw.TextGrid>`  
 
 ```{code-cell} ipython3
 import pathlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ doc = [
     "jupytext >=1.13.8",
     "librosa >=0.9.1",
     "myst-nb >=0.15.0",
-    "osfclient >=0.0.5",
     "pyprojroot >=0.2.0",
     "seaborn >=0.11.2",
     "Sphinx >=3.4.3",


### PR DESCRIPTION
- Remove doc/data/r6paq/b17_concat_dtw.TextGrid because it's 11 MB and takes forever to load with the new TextGrid class
- Fix toctree in doc/howto.md
- Fix links in howto/convert-simple-seq.md
- Fix download links in doc/howto/munging-annotations-textgrid.md