### PR TITLE
Remove exceptions from birdsongrec.py

### DIFF
--- a/src/crowsetta/birdsongrec.py
+++ b/src/crowsetta/birdsongrec.py
@@ -69,12 +69,6 @@ def birdsongrec2annot(annot_path='Annotation.xml', concat_seqs_into_songs=True,
     else:
         wavpath = Path(wavpath)
 
-    if not wavpath.exists():
-        raise NotADirectoryError(
-            "Value specified for 'wavpath' not recognized as an existing directory."
-            f"\nValue for 'wavpath' was: {wavpath}"
-        )
-
     # `birdsong-recongition-dataset` also has a 'Sequence' class
     # but it is slightly different from the `generic.Sequence` used by `crowsetta`
     seq_list_xml = birdsongrec.parse_xml(annot_path,
@@ -88,11 +82,7 @@ def birdsongrec2annot(annot_path='Annotation.xml', concat_seqs_into_songs=True,
 
         wav_filename = os.path.join(wavpath, seq_xml.wav_file)
         wav_filename = os.path.abspath(wav_filename)
-        if not os.path.isfile(wav_filename):
-            raise FileNotFoundError(
-                f'.wav file {wav_filename} specified in '
-                f'annotation file {annot_path} is not found'
-            )
+
         samp_freq = soundfile.info(wav_filename).samplerate
         onsets_s = np.round(onset_inds / samp_freq, decimals=3)
         offsets_s = np.round(offset_inds / samp_freq, decimals=3)


### PR DESCRIPTION
This removes NotADirectory and FileNotFound errors raised by `birdsongrec2annot` when `wavpath` doesn't exist or it can't find the wav files in the specified `wavpath`, respectively.

My intent was to make sure the files were there, if something else depended on them.
But this prevents someone from accessing the annotations if they don't have the wav files. Which is the opposite of the point of this package.

It also requires extra logic from a downstream library -- e.g. I'm hitting these errors in vak right now because I'm trying to open the annotation file inside a directory where I don't have (and don't want to have) the wav files -- I'm using the annotations with spectrograms generated from the audio.

So this removes the errors -- they're more trouble than they're worth. Will do the same in the current version, but vak still depends on 3.4.x