### PR TITLE
Revert "Remove exceptions from birdsongrec.py"

### DIFF
--- a/src/crowsetta/birdsongrec.py
+++ b/src/crowsetta/birdsongrec.py
@@ -69,6 +69,12 @@ def birdsongrec2annot(annot_path='Annotation.xml', concat_seqs_into_songs=True,
     else:
         wavpath = Path(wavpath)
 
+    if not wavpath.exists():
+        raise NotADirectoryError(
+            "Value specified for 'wavpath' not recognized as an existing directory."
+            f"\nValue for 'wavpath' was: {wavpath}"
+        )
+
     # `birdsong-recongition-dataset` also has a 'Sequence' class
     # but it is slightly different from the `generic.Sequence` used by `crowsetta`
     seq_list_xml = birdsongrec.parse_xml(annot_path,
@@ -82,7 +88,11 @@ def birdsongrec2annot(annot_path='Annotation.xml', concat_seqs_into_songs=True,
 
         wav_filename = os.path.join(wavpath, seq_xml.wav_file)
         wav_filename = os.path.abspath(wav_filename)
-
+        if not os.path.isfile(wav_filename):
+            raise FileNotFoundError(
+                f'.wav file {wav_filename} specified in '
+                f'annotation file {annot_path} is not found'
+            )
         samp_freq = soundfile.info(wav_filename).samplerate
         onsets_s = np.round(onset_inds / samp_freq, decimals=3)
         offsets_s = np.round(offset_inds / samp_freq, decimals=3)


### PR DESCRIPTION
This reverts commit c22804052e5509ca2ae027305544da15e18fee18.

We do actually need to check for audio with this annotation format, since we use the audio to get the sampling rate and convert the onsets and offsets from sample numbers to seconds. There might be a more flexible way to handle this long term, but this did not fix the problem I had upstream with vak so I'm just going to revert it for now.