### PR TITLE
DEV: Require python gte 3p11 bump lower bounds scipy stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", 3.11, 3.12]
+        python-version: [3.11, 3.12, 3.13]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
           src: "./src"
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.13"
       - name: install libsndfile1 on ubuntu
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt install libsndfile1

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ build:
   apt_packages:
     - libsndfile1
   tools:
-    python: "3.10"
+    python: "3.13"
 
 sphinx:
    configuration: doc/conf.py

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,6 +12,13 @@ VENV_DIR = pathlib.Path('./.venv').resolve()
 nox.options.sessions = ['test', 'coverage']
 
 
+TEST_PYTHONS = [
+    "3.11",
+    "3.12",
+    "3.13",
+]
+
+
 @nox.session
 def build(session: nox.Session) -> None:
     """
@@ -26,7 +33,7 @@ def build(session: nox.Session) -> None:
     session.run("flit", "build")
 
 
-@nox.session(python="3.10")
+@nox.session(python=TEST_PYTHONS[1])
 def dev(session: nox.Session) -> None:
     """
     Sets up a python development environment for the project.
@@ -54,7 +61,7 @@ def dev(session: nox.Session) -> None:
     session.run(python, "-m", "pip", "install", "-e", ".[dev,test,doc]", external=True)
 
 
-@nox.session(python="3.10")
+@nox.session(python=TEST_PYTHONS[1])
 def lint(session):
     """
     Run the linter.
@@ -64,13 +71,6 @@ def lint(session):
     session.run("isort", "./src")
     session.run("black", "./src", "--line-length=120")
     session.run("flake8", "./src", "--max-line-length", "120", "--exclude", "./src/crowsetta/_vendor")
-
-
-TEST_PYTHONS = [
-    "3.11",
-    "3.12",
-    "3.13",
-]
 
 
 @nox.session(python=TEST_PYTHONS)

--- a/noxfile.py
+++ b/noxfile.py
@@ -67,9 +67,9 @@ def lint(session):
 
 
 TEST_PYTHONS = [
-    "3.10",
     "3.11",
     "3.12",
+    "3.13",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "A Python tool to work with any format for annotating animal sound
 authors = [
     {name = "David Nicholson", email = "nickledave@users.noreply.github.com"}
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "appdirs >=1.4.4",
     "attrs >=19.3.0",
@@ -26,9 +26,9 @@ classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: Implementation :: CPython',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,10 @@ requires-python = ">=3.11"
 dependencies = [
     "appdirs >=1.4.4",
     "attrs >=19.3.0",
-    "numpy >=1.22.0",
-    "pandas >= 1.4.0",
+    "numpy >=1.26.0",
+    "pandas >= 2.1.0",
     "pandera >= 0.9.0",
-    "scipy >=1.8.0",
+    "scipy >=1.12.0",
     "SoundFile >=0.12.1",
 ]
 version = "5.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,12 @@ authors = [
 requires-python = ">=3.11"
 dependencies = [
     "appdirs >=1.4.4",
-    "attrs >=19.3.0",
+    "attrs >=25.3.0",
     "numpy >=1.26.0",
     "pandas >= 2.1.0",
-    "pandera >= 0.9.0",
+    "pandera >= 0.25.0",
     "scipy >=1.12.0",
-    "SoundFile >=0.12.1",
+    "SoundFile >=0.13.1",
 ]
 version = "5.1.0"
 readme = "README.md"

--- a/src/crowsetta/formats/seq/generic.py
+++ b/src/crowsetta/formats/seq/generic.py
@@ -38,7 +38,7 @@ Both units can also be specified. Conversion between units is not validated.
 
 class GenericSeqSchema(pandera.pandas.DataFrameModel):
     """A :class: `pandera.pandas.DataFrameModel` that validates
-    a :type:`pandas.DataFrame` loaded from a csv file 
+    a :type:`pandas.DataFrame` loaded from a csv file
     in the ``'generic-seq'`` annotation format.
     """
 
@@ -61,7 +61,7 @@ class GenericSeqSchema(pandera.pandas.DataFrameModel):
             return all([col in df for col in ("onset_s", "offset_s")])
         else:
             return True
-    
+
     @pandera.pandas.dataframe_check(error=ONSET_OFFSET_COLS_ERR)
     def both_onset_sample_and_offset_sample_if_either(cls, df: pd.DataFrame) -> bool:
         """check that, if one of {'onset_sample', 'offset_sample'} column is present,

--- a/src/crowsetta/formats/seq/textgrid/classes.py
+++ b/src/crowsetta/formats/seq/textgrid/classes.py
@@ -1,5 +1,4 @@
-"""Data classes used to represent components of TextGrids.
-"""
+"""Data classes used to represent components of TextGrids."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
This bumps requires-python to >= 3.11, to fix #287, and bumps lower bounds on dependencies while we're at it, to fix #288.