### PR TITLE
Drop support for old dependency versions, fix #298

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.11, 3.12, 3.13]
+        python-version: [3.12, 3.13, 3.14]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,13 +10,10 @@ build:
     - libsndfile1
   tools:
     python: "3.13"
+  jobs:
+    install:
+      - python -m pip install --no-cache dir "pip >= 25.1"
+      - python -m pip install --upgrade --upgrade-strategy only-if-needed --no-cache-dir --group doc .
 
 sphinx:
    configuration: doc/conf.py
-
-python:
-   install:
-     - method: pip
-       path: .
-       extra_requirements:
-        - doc

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     python: "3.13"
   jobs:
     install:
-      - python -m pip install --no-cache dir "pip >= 25.1"
+      - python -m pip install --no-cache-dir "pip >= 25.1"
       - python -m pip install --upgrade --upgrade-strategy only-if-needed --no-cache-dir --group doc .
 
 sphinx:

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,9 +13,9 @@ nox.options.sessions = ['test', 'coverage']
 
 
 TEST_PYTHONS = [
-    "3.11",
     "3.12",
     "3.13",
+    "3.14",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     'Programming Language :: Python :: Implementation :: CPython',
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 test = [
     "pytest >=6.2.1",
     "pytest-cov >=2.12.0",
@@ -56,13 +56,15 @@ doc = [
 ]
 dev = [
     'black >=23.1.0',
-    'crowsetta[doc, test]',
     'flake8 >=6.0.0',
-    'flit',
     'isort >=5.12.0',
     'pycln >=2.1.3',
     'twine',
+    {include-group = "test"},
+    {include-group = "doc"},
+
 ]
+
 
 [project.urls]
 Source = "https://github.com/vocalpy/crowsetta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,12 @@ description = "A Python tool to work with any format for annotating animal sound
 authors = [
     {name = "David Nicholson", email = "nickledave@users.noreply.github.com"}
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "appdirs >=1.4.4",
     "attrs >=25.3.0",
-    "numpy >=1.26.0",
-    "pandas >= 2.1.0",
+    "numpy >=2.0.0",
+    "pandas >= 2.2.0",
     "pandera >= 0.25.0",
     "scipy >=1.12.0",
     "SoundFile >=0.13.1",
@@ -39,7 +39,7 @@ test = [
     "pytest-xdist >=3.2.0",
 ]
 doc = [
-    "ipython != 8.7.0",
+    "ipython >= 8.20.0",
     "jupyterlab >=3.0.3",
     "jupytext >=1.13.8",
     "librosa >=0.9.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,12 +54,15 @@ doc = [
     "sphinxext-opengraph  >=0.5.1",
     "sphinx-tabs >= 3.3.1",
 ]
-dev = [
+lint = [
     'black >=23.1.0',
     'flake8 >=6.0.0',
     'isort >=5.12.0',
     'pycln >=2.1.3',
+]
+dev = [
     'twine',
+    {include-group = "lint"},
     {include-group = "test"},
     {include-group = "doc"},
 


### PR DESCRIPTION
As per [SPEC 0](https://scientific-python.org/specs/spec-0000/), specifically 2025 Q3 and Q4 recommended drops