### PR TITLE
DEV: Drop support for older dependency versions, fix #298

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.11, 3.12, 3.13]
+        python-version: [3.12, 3.13, 3.14]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,9 +13,9 @@ nox.options.sessions = ['test', 'coverage']
 
 
 TEST_PYTHONS = [
-    "3.11",
     "3.12",
     "3.13",
+    "3.14",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,12 @@ description = "A Python tool to work with any format for annotating animal sound
 authors = [
     {name = "David Nicholson", email = "nickledave@users.noreply.github.com"}
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "appdirs >=1.4.4",
     "attrs >=25.3.0",
-    "numpy >=1.26.0",
-    "pandas >= 2.1.0",
+    "numpy >=2.0.0",
+    "pandas >= 2.2.0",
     "pandera >= 0.25.0",
     "scipy >=1.12.0",
     "SoundFile >=0.13.1",
@@ -39,7 +39,7 @@ test = [
     "pytest-xdist >=3.2.0",
 ]
 doc = [
-    "ipython != 8.7.0",
+    "ipython >= 8.20.0",
     "jupyterlab >=3.0.3",
     "jupytext >=1.13.8",
     "librosa >=0.9.1",


### PR DESCRIPTION
As per [SPEC 0](https://scientific-python.org/specs/spec-0000/), specifically 2025 Q3 and Q4 recommended drops